### PR TITLE
fix routing-back-to-arb-tab bug

### DIFF
--- a/src/components/ExchangePage/index.jsx
+++ b/src/components/ExchangePage/index.jsx
@@ -245,7 +245,7 @@ function getMarketRate(
   }
 }
 
-function ExchangePage({ initialCurrency, sending = false, params, location: { pathname } }) {
+function ExchangePage({ initialCurrency, sending = false, params, location: { pathname='' } }) {
   const { t } = useTranslation()
   const { account } = useWeb3Context()
 

--- a/src/components/ExchangePage/index.jsx
+++ b/src/components/ExchangePage/index.jsx
@@ -15,12 +15,13 @@ import OversizedPanel from '../OversizedPanel'
 import TransactionDetails from '../TransactionDetails'
 import ArrowDown from '../../assets/svg/SVGArrowDown'
 import { amountFormatter, calculateGasMargin } from '../../utils'
-import { useExchangeContract } from '../../hooks'
+import { useExchangeContract, useClearBrowserQueries } from '../../hooks'
 import { useTokenDetails } from '../../contexts/Tokens'
 import { useTransactionAdder } from '../../contexts/Transactions'
 import { useAddressBalance, useExchangeReserves } from '../../contexts/Balances'
 import { useFetchAllBalances } from '../../contexts/AllBalances'
 import { useAddressAllowance } from '../../contexts/Allowances'
+import { withRouter } from 'react-router'
 
 const INPUT = 0
 const OUTPUT = 1
@@ -244,7 +245,7 @@ function getMarketRate(
   }
 }
 
-export default function ExchangePage({ initialCurrency, sending = false, params }) {
+function ExchangePage({ initialCurrency, sending = false, params, location: { pathname } }) {
   const { t } = useTranslation()
   const { account } = useWeb3Context()
 
@@ -504,10 +505,7 @@ export default function ExchangePage({ initialCurrency, sending = false, params 
     t
   ])
 
-  useEffect(() => {
-    const history = createBrowserHistory()
-    history.push(window.location.pathname + '')
-  }, [])
+  useClearBrowserQueries(pathname)
 
   const [inverted, setInverted] = useState(false)
   const exchangeRate = getExchangeRate(inputValueParsed, inputDecimals, outputValueParsed, outputDecimals)
@@ -769,3 +767,5 @@ export default function ExchangePage({ initialCurrency, sending = false, params 
     </>
   )
 }
+
+export default withRouter(ExchangePage)

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -160,6 +160,6 @@ export function useCopyClipboard(timeout = 500) {
 export function useClearBrowserQueries(pathname = '') {
   useEffect(() => {
     const history = createBrowserHistory()
-    history.push(`/#${pathname}`)
+    history.push(pathname)
   }, [pathname])
 }

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -4,6 +4,7 @@ import { useWeb3Context } from 'web3-react'
 import ERC20_ABI from '../constants/abis/erc20'
 import { getContract, getFactoryContract, getExchangeContract, isAddress } from '../utils'
 import copy from 'copy-to-clipboard'
+import { createBrowserHistory } from 'history'
 
 // modified from https://usehooks.com/useDebounce/
 export function useDebounce(value, delay) {
@@ -154,4 +155,11 @@ export function useCopyClipboard(timeout = 500) {
   }, [isCopied, setIsCopied, timeout])
 
   return [isCopied, staticCopy]
+}
+
+export function useClearBrowserQueries(pathname = '') {
+  useEffect(() => {
+    const history = createBrowserHistory()
+    history.push(`/#${pathname}`)
+  }, [pathname])
 }

--- a/src/pages/App.js
+++ b/src/pages/App.js
@@ -1,6 +1,6 @@
 import React, { Suspense, lazy } from 'react'
 import styled from 'styled-components'
-import { HashRouter, Redirect, Route, Switch } from 'react-router-dom'
+import { Redirect, Route, Switch, BrowserRouter } from 'react-router-dom'
 
 import Web3ReactManager from '../components/Web3ReactManager'
 import Header from '../components/Header'
@@ -60,7 +60,7 @@ export default function App() {
           <BodyWrapper>
             <Body>
               <Web3ReactManager>
-                <HashRouter>
+                <BrowserRouter>
                   <NavigationTabs />
                   {/* this Suspense is for route code-splitting */}
                   <Suspense fallback={null}>
@@ -110,7 +110,7 @@ export default function App() {
                       <Redirect to="/arbitrum" />
                     </Switch>
                   </Suspense>
-                </HashRouter>
+                </BrowserRouter>
               </Web3ReactManager>
             </Body>
           </BodyWrapper>

--- a/src/pages/Pool/AddLiquidity.js
+++ b/src/pages/Pool/AddLiquidity.js
@@ -12,7 +12,7 @@ import OversizedPanel from '../../components/OversizedPanel'
 import ContextualInfo from '../../components/ContextualInfo'
 import { ReactComponent as Plus } from '../../assets/images/plus-blue.svg'
 
-import { useExchangeContract } from '../../hooks'
+import { useExchangeContract, useClearBrowserQueries } from '../../hooks'
 import { amountFormatter, calculateGasMargin } from '../../utils'
 import { useTransactionAdder } from '../../contexts/Transactions'
 import { useTokenDetails } from '../../contexts/Tokens'
@@ -20,6 +20,7 @@ import { useFetchAllBalances } from '../../contexts/AllBalances'
 import { useAddressBalance, useExchangeReserves } from '../../contexts/Balances'
 import { useAddressAllowance } from '../../contexts/Allowances'
 
+import { withRouter } from 'react-router-dom'
 const INPUT = 0
 const OUTPUT = 1
 
@@ -198,15 +199,11 @@ function getMarketRate(reserveETH, reserveToken, decimals, invert = false) {
   return getExchangeRate(reserveETH, 18, reserveToken, decimals, invert)
 }
 
-export default function AddLiquidity({ params }) {
+function AddLiquidity({ params, location: { pathname = '' } }) {
   const { t } = useTranslation()
   const { library, active, account } = useWeb3Context()
 
-  // clear url of query
-  useEffect(() => {
-    const history = createBrowserHistory()
-    history.push(window.location.pathname + '')
-  }, [])
+  useClearBrowserQueries(pathname)
 
   const [addLiquidityState, dispatchAddLiquidityState] = useReducer(
     addLiquidityStateReducer,
@@ -668,3 +665,5 @@ export default function AddLiquidity({ params }) {
     </>
   )
 }
+
+export default withRouter(AddLiquidity)

--- a/src/pages/Pool/CreateExchange.js
+++ b/src/pages/Pool/CreateExchange.js
@@ -9,7 +9,7 @@ import ReactGA from 'react-ga'
 import { Button } from '../../theme'
 import AddressInputPanel from '../../components/AddressInputPanel'
 import OversizedPanel from '../../components/OversizedPanel'
-import { useFactoryContract } from '../../hooks'
+import { useFactoryContract, useClearBrowserQueries } from '../../hooks'
 import { useTokenDetails } from '../../contexts/Tokens'
 import { useTransactionAdder } from '../../contexts/Transactions'
 
@@ -69,10 +69,7 @@ function CreateExchange({ location, params }) {
   const addTransaction = useTransactionAdder()
 
   // clear url of query
-  useEffect(() => {
-    const history = createBrowserHistory()
-    history.push(window.location.pathname + '')
-  }, [])
+  useClearBrowserQueries(location.pathname)
 
   // validate everything
   const [errorMessage, setErrorMessage] = useState(!account && t('noWallet'))

--- a/src/pages/Pool/RemoveLiquidity.js
+++ b/src/pages/Pool/RemoveLiquidity.js
@@ -12,12 +12,13 @@ import ContextualInfo from '../../components/ContextualInfo'
 import OversizedPanel from '../../components/OversizedPanel'
 import ArrowDown from '../../assets/svg/SVGArrowDown'
 
-import { useExchangeContract } from '../../hooks'
+import { useExchangeContract, useClearBrowserQueries } from '../../hooks'
 import { useTransactionAdder } from '../../contexts/Transactions'
 import { useTokenDetails } from '../../contexts/Tokens'
 import { useAddressBalance } from '../../contexts/Balances'
 import { useFetchAllBalances } from '../../contexts/AllBalances'
 import { calculateGasMargin, amountFormatter } from '../../utils'
+import { withRouter } from 'react-router-dom'
 
 // denominated in bips
 const ALLOWED_SLIPPAGE = ethers.utils.bigNumberify(200)
@@ -142,17 +143,13 @@ function calculateSlippageBounds(value) {
   }
 }
 
-export default function RemoveLiquidity({ params }) {
+function RemoveLiquidity({ params, location: { pathname = '' } }) {
   const { library, account, active } = useWeb3Context()
   const { t } = useTranslation()
 
   const addTransaction = useTransactionAdder()
 
-  // clear url of query
-  useEffect(() => {
-    const history = createBrowserHistory()
-    history.push(window.location.pathname + '')
-  }, [])
+  useClearBrowserQueries(pathname)
 
   const [outputCurrency, setOutputCurrency] = useState(params.poolTokenAddress)
   const [value, setValue] = useState(params.poolTokenAmount ? params.poolTokenAmount : '')
@@ -431,3 +428,5 @@ export default function RemoveLiquidity({ params }) {
     </>
   )
 }
+
+export default withRouter(RemoveLiquidity)


### PR DESCRIPTION
Gets current path from react-router instead of `window.location`; client side routing is essentially a browser-hack to begin with, so playing by react-router's rules is safer.

"But why is it that they/we keep reseting the path so often in the first place?"
It appears to be so that urls with query params (i.e., send/0xmyaddress) don't get carried over into future routes, tho to be honest, if I just get rid of this query-clearing entirely, I wasn't able to trigger any misbehavior. In any case, this ought to preserve what was already in place, whatever it's motivation was. 


    