### PR TITLE
Etherscan links

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -35,11 +35,15 @@ const ETHERSCAN_PREFIXES = {
 }
 
 export function getEtherscanLink(networkId, data, type) {
+  // overwrite Arb overlay network id with Ropsten:
+  networkId = 3
+  
   const prefix = `https://${ETHERSCAN_PREFIXES[networkId] || ETHERSCAN_PREFIXES[1]}etherscan.io`
 
   switch (type) {
     case 'transaction': {
-      return `${prefix}/tx/${data}`
+      // transactions just link to rollup address? getQueryParam(window.location, '')
+      return `${prefix}/address/0xdd85b046ba8e450223d66028d123a828a7e11c19`
     }
     case 'address':
     default: {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -42,7 +42,7 @@ export function getEtherscanLink(networkId, data, type) {
 
   switch (type) {
     case 'transaction': {
-      // transactions just link to rollup address? getQueryParam(window.location, '')
+      // transactions just link to rollup address?
       return `${prefix}/address/0xdd85b046ba8e450223d66028d123a828a7e11c19`
     }
     case 'address':


### PR DESCRIPTION
fixes https://github.com/OffchainLabs/uniswap-frontend/issues/11

Accounts just link to kovan account on l1, and txns just link to rollup address? 