### PR TITLE
move useTokenBridgeHook to up to App

### DIFF
--- a/src/pages/App.js
+++ b/src/pages/App.js
@@ -10,7 +10,9 @@ import NavigationTabs from '../components/NavigationTabs'
 import { isAddress, getAllQueryParams } from '../utils'
 import WelcomeModal from '../components/WelcomeModal'
 import { useLocalStorage } from '@rehooks/local-storage'
-
+import { useArbTokenBridge } from 'arb-token-bridge'
+import { ethers } from 'ethers'
+import { useUpdateFundsMessage } from '../contexts/FundsMessage'
 const Swap = lazy(() => import('./Swap'))
 const Send = lazy(() => import('./Send'))
 const Pool = lazy(() => import('./Pool'))
@@ -54,6 +56,16 @@ export default function App() {
   const params = getAllQueryParams()
   const [shouldOpenModalCache, setShouldOpenModalCache] = useLocalStorage('welcomeModal', true)
 
+  const { balances, bridgeTokens, ...bridge }  = useArbTokenBridge(
+    process.env.REACT_APP_ARB_VALIDATOR_URL,
+    // new ethers.providers.Web3Provider(library.provider),
+    new ethers.providers.Web3Provider(window.ethereum),
+    process.env.REACT_APP_ARB_AGGREGATOR_URL,
+    true,
+    0,
+    true
+  )
+  useUpdateFundsMessage(bridge, balances)
   return (
     <>
       <Suspense fallback={null}>
@@ -114,7 +126,7 @@ export default function App() {
                         ]}
                         component={() => <Pool params={params} />}
                       />
-                      <Route exact path="/arbitrum" component={() => <Bridge />} />
+                      <Route exact path="/arbitrum" component={() => <Bridge balances={balances} bridgeTokens={bridgeTokens} bridge={bridge}  />} />
                       <Redirect to="/arbitrum" />
                     </Switch>
                   </Suspense>

--- a/src/pages/Bridge/index.jsx
+++ b/src/pages/Bridge/index.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import styled from 'styled-components'
 import { useTranslation } from 'react-i18next'
-import { useArbTokenBridge, TokenType } from 'arb-token-bridge'
+import { TokenType } from 'arb-token-bridge'
 import { ethers } from 'ethers'
 import { lighten, darken } from 'polished'
 import Tooltip from '@reach/tooltip'
@@ -16,7 +16,6 @@ import Modal from '../../components/Modal'
 import { DownArrow, DownArrowBackground } from '../../components/ExchangePage'
 import { amountFormatter, getEtherscanLink } from '../../utils'
 import { ColoredDropdown } from '../Pool/ModeSelector'
-import { useUpdateFundsMessage } from '../../contexts/FundsMessage'
 import { Link } from '../../theme'
 import SpinnerButton from '../../components/SpinnerButton'
 
@@ -139,7 +138,7 @@ const TransferType = {
 const ETH_TOKEN = 'ETH'
 
 // TODO symbol image search overrides for each symbol if possible
-export default function Bridge({ params = defaultBridgeParams }) {
+export default function Bridge( { balances, bridgeTokens, bridge }) {
   const l1NetworkId = window.ethereum.networkVersion
   const [transferType, setTransferType] = useState(TransferType.toArb)
   const [transferValue, setTransferValue] = useState('0.0')
@@ -149,15 +148,6 @@ export default function Bridge({ params = defaultBridgeParams }) {
   const [errorMessage, setErrorMessage] = useState('')
 
   const { t: translated } = useTranslation()
-  const { balances, bridgeTokens, ...bridge } = useArbTokenBridge(
-    process.env.REACT_APP_ARB_VALIDATOR_URL,
-    // new ethers.providers.Web3Provider(library.provider),
-    new ethers.providers.Web3Provider(window.ethereum),
-    process.env.REACT_APP_ARB_AGGREGATOR_URL,
-    true,
-    0,
-    true
-  )
   const unlockToken = bridge.token.approve
 
   const vmIdParsed = bridge.vmId.slice(0, 8) || '0x'
@@ -324,7 +314,6 @@ export default function Bridge({ params = defaultBridgeParams }) {
       .map(tx => tx.value)
       .reduce((total, current) => total.add(current), ethers.constants.Zero)
   }
-  useUpdateFundsMessage(bridge, balances)
 
   useEffect(() => {
     if (!bridge.walletAddress || !bridge.vmId) return


### PR DESCRIPTION
Bridge hook gets instantiated in main App component instead of bridge panel (i.e., on-load, no matter what). Old way was causing some friction, particularly when the page is loaded on a different panel (stale balances, "send funds" pop up not showing, etc). Lifting it shouldn't have any negative side effects. 